### PR TITLE
Do not mention plugin.audio.srfplayradio

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,3 @@ Currently, these Kodi plugins use `script.module.srgssr`:
 * [plugin.video.srfplaytv](https://github.com/goggle/plugin.video.srfplaytv)
 * [plugin.video.rtsplaytv](https://github.com/goggle/plugin.video.rtsplaytv)
 * [plugin.video.rsiplaytv](https://github.com/goggle/plugin.video.rsiplaytv)
-* [plugin.audio.srfplayradio](https://github.com/goggle/plugin.audio.srfplayradio)


### PR DESCRIPTION
Plugin `plugin.audio.srfplayradio` is currently not supported.
The new APIv3 does not support the audio library, so `script.module.srgssr` will only be suitable for video plugins.