### PR TITLE
Fix DRM slideshow playback

### DIFF
--- a/lib/manifest_proxy.py
+++ b/lib/manifest_proxy.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2018 Alexander Seiler
+#
+#
+# This file is part of script.module.srgssr.
+#
+# script.module.srgssr is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# script.module.srgssr is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with script.module.srgssr.
+# If not, see <http://www.gnu.org/licenses/>.
+
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+# Safety net only, in case wait_until_playback_stops() never runs (e.g. crash).
+IDLE_TIMEOUT_SECONDS = 3 * 60 * 60
+WATCHDOG_INTERVAL_SECONDS = 30
+STARTUP_TIMEOUT_SECONDS = 60
+
+
+class ManifestProxyServer:
+    """Serves a locally-filtered DASH manifest, re-fetching it on every request.
+
+    This keeps the manifest live-updated for the whole playback session, and
+    ties its own lifetime to actual playback (stopped/ended/error) instead of a
+    fixed timer.
+
+    Kodi stops delivering xbmc.Player callbacks once the invoking plugin
+    script exits, which normally happens right after resolving the URL. So
+    the caller must block in wait_until_playback_stops() to keep the script
+    (and this server) alive for as long as the stream plays.
+    """
+
+    def __init__(self, refresh, initial_xml, logger=None):
+        """
+        refresh     -- callable() -> bytes or None; None means "fetch failed",
+                       keep serving the last good manifest.
+        initial_xml -- bytes, the manifest already fetched once by the caller.
+        logger      -- optional callable(str) for diagnostic logging.
+        """
+        self._refresh = refresh
+        self._log = logger or (lambda msg: None)
+        self._lock = threading.Lock()
+        self._xml = initial_xml
+        self._last_request = time.monotonic()
+        self._stopped = threading.Event()
+
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, format, *args):
+                pass
+
+            def _send_headers(self, length):
+                self.send_response(200)
+                self.send_header('Content-type', 'application/dash+xml')
+                self.send_header('Content-Length', str(length))
+                self.end_headers()
+
+            def do_HEAD(self):
+                with outer._lock:
+                    body = outer._xml
+                self._send_headers(len(body))
+
+            def do_GET(self):
+                with outer._lock:
+                    outer._last_request = time.monotonic()
+                fresh = outer._safe_refresh()
+                with outer._lock:
+                    if fresh is not None:
+                        outer._xml = fresh
+                    body = outer._xml
+                self._send_headers(len(body))
+                self.wfile.write(body)
+
+        self._server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+        self.port = self._server.server_port
+
+        threading.Thread(target=self._run_server, daemon=True).start()
+        threading.Thread(target=self._watchdog, daemon=True).start()
+
+    @property
+    def url(self):
+        return f"http://127.0.0.1:{self.port}/manifest.mpd"
+
+    def _safe_refresh(self):
+        try:
+            return self._refresh()
+        except Exception as e:
+            self._log(f"ManifestProxyServer: refresh failed: {e}")
+            return None
+
+    def _run_server(self):
+        try:
+            self._server.serve_forever(poll_interval=0.5)
+        finally:
+            self._server.server_close()
+
+    def _watchdog(self):
+        while not self._stopped.wait(WATCHDOG_INTERVAL_SECONDS):
+            with self._lock:
+                idle = time.monotonic() - self._last_request
+            if idle > IDLE_TIMEOUT_SECONDS:
+                self._log("ManifestProxyServer: idle timeout reached, shutting down")
+                self.stop()
+                break
+
+    def stop(self):
+        if self._stopped.is_set():
+            return
+        self._stopped.set()
+        self._server.shutdown()
+
+    def wait_until_playback_stops(self, player, poll_interval=1.0):
+        """Blocks the calling (plugin script) thread until `player` is no
+        longer playing our manifest URL, then stops the server.
+
+        Must be called from the plugin script's own thread -- that's the
+        only thread Kodi keeps delivering playback state to after
+        setResolvedUrl().
+        """
+        # Wait for playback to start, giving up if it never does.
+        start = time.monotonic()
+        while not self._stopped.is_set():
+            if player.isPlayingVideo() and player.getPlayingFile() == self.url:
+                break
+            if time.monotonic() - start > STARTUP_TIMEOUT_SECONDS:
+                self._log("ManifestProxyServer: playback never started, shutting down")
+                self.stop()
+                return
+            if self._stopped.wait(poll_interval):
+                return
+
+        while not self._stopped.is_set():
+            if not (player.isPlayingVideo() and player.getPlayingFile() == self.url):
+                break
+            if self._stopped.wait(poll_interval):
+                return
+
+        self.stop()

--- a/lib/play.py
+++ b/lib/play.py
@@ -19,14 +19,25 @@
 
 from urllib.parse import parse_qsl, ParseResult
 from urllib.parse import urlparse as urlps
+from urllib.parse import urlparse
 
 import json
+import xml.etree.ElementTree as ET
+
+import requests
+import xbmc
 import xbmcgui
 import xbmcplugin
 
 import inputstreamhelper
 
 import utils
+from manifest_proxy import ManifestProxyServer
+
+# Force Python to use the standard DASH/CENC/PlayReady XML tags when serializing
+ET.register_namespace('', 'urn:mpeg:dash:schema:mpd:2011')
+ET.register_namespace('cenc', 'urn:mpeg:cenc:2013')
+ET.register_namespace('mspr', 'urn:microsoft:playready')
 
 
 class Player:
@@ -199,9 +210,22 @@ class Player:
             self.srgssr.log("play_drm: Unable to setup drm")
             return
 
-        play_item = xbmcgui.ListItem(
-            title, path=self.srgssr.get_auth_url(resource_data["url"])
-        )
+        auth_url = self.srgssr.get_auth_url(resource_data["url"])
+        play_item_path = auth_url
+        manifest_update_url = auth_url
+        use_local_manifest = False
+
+        try:
+            xml_data, removed_any = self._fetch_filtered_manifest(resource_data["url"])
+            if xml_data is not None and removed_any:
+                proxy = self._start_manifest_proxy(resource_data["url"], xml_data)
+                play_item_path = proxy.url
+                manifest_update_url = proxy.url
+                use_local_manifest = True
+        except Exception as e:
+            self.srgssr.log(f"play_drm: Error modifying manifest: {e}")
+
+        play_item = xbmcgui.ListItem(title, path=play_item_path)
         ia = "inputstream.adaptive"
         play_item.setProperty("inputstream", ia)
         lic_key = (
@@ -211,4 +235,80 @@ class Player:
         play_item.setProperty(f"{ia}.manifest_type", manifest_type)
         play_item.setProperty(f"{ia}.license_type", drm)
         play_item.setProperty(f"{ia}.license_key", lic_key)
+        if use_local_manifest:
+            play_item.setProperty(f"{ia}.manifest_update_url", manifest_update_url)
         xbmcplugin.setResolvedUrl(self.handle, True, play_item)
+
+        if use_local_manifest:
+            # Blocks until playback ends, keeping the proxy alive that long.
+            proxy.wait_until_playback_stops(xbmc.Player())
+
+    def _start_manifest_proxy(self, stream_url, initial_xml):
+        """Starts a ManifestProxyServer that keeps re-fetching/filtering `stream_url`."""
+
+        def refresh():
+            xml_data, _ = self._fetch_filtered_manifest(stream_url)
+            return xml_data
+
+        return ManifestProxyServer(refresh, initial_xml, logger=self.srgssr.log)
+
+    def _fetch_filtered_manifest(self, stream_url):
+        """Fetches the manifest for `stream_url`, rewrites its BaseURL to point
+        directly at the origin, and strips out trickmode tracks.
+
+        Returns a (xml_bytes, removed_any) tuple. xml_bytes is None if the
+        manifest could not be fetched or parsed.
+        """
+        auth_url = self.srgssr.get_auth_url(stream_url, notify_on_error=False)
+        manifest_content = self._quiet_fetch(auth_url)
+        if not manifest_content:
+            return None, False
+
+        root = ET.fromstring(manifest_content.encode('utf-8'))
+        ns = {'mpd': 'urn:mpeg:dash:schema:mpd:2011'}
+
+        # This points Kodi to the remote server for the actual video segments
+        base_elem = ET.Element('{urn:mpeg:dash:schema:mpd:2011}BaseURL')
+        parsed_url = urlparse(auth_url)
+        base_elem.text = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path.rsplit('/', 1)[0]}/"
+        root.insert(0, base_elem)
+
+        periods = root.findall('.//mpd:Period', ns) or root.findall('.//Period')
+        removed_any = False
+
+        # Strip out the trickmode tracks completely
+        for period in periods:
+            adaptation_sets = period.findall('mpd:AdaptationSet', ns) or period.findall('AdaptationSet')
+            for aset in adaptation_sets:
+                is_trickmode = False
+                for prop in aset.findall('mpd:EssentialProperty', ns) or aset.findall('EssentialProperty'):
+                    if 'trickmode' in prop.get('schemeIdUri', ''):
+                        is_trickmode = True
+                for prop in aset.findall('mpd:SupplementalProperty', ns) or aset.findall('SupplementalProperty'):
+                    if 'trickmode' in prop.get('schemeIdUri', ''):
+                        is_trickmode = True
+                if is_trickmode:
+                    period.remove(aset)
+                    removed_any = True
+
+        return ET.tostring(root, encoding='utf-8'), removed_any
+
+    def _quiet_fetch(self, url):
+        """Like srgssr.open_url(use_cache=False), but without a UI notification
+        on failure -- used for background manifest refreshes during playback."""
+        try:
+            headers = {
+                "User-Agent": (
+                    "Mozilla/5.0 (X11; Linux x86_64; rv:136.0) "
+                    "Gecko/20100101 Firefox/136.0"
+                )
+            }
+            response = requests.get(url, headers=headers, timeout=10)
+            if not response.ok:
+                self.srgssr.log(f"_quiet_fetch: {url} returned status {response.status_code}")
+                return ""
+            response.encoding = "UTF-8"
+            return response.text
+        except requests.RequestException as e:
+            self.srgssr.log(f"_quiet_fetch: failed to fetch {url}: {e}")
+            return ""

--- a/lib/play.py
+++ b/lib/play.py
@@ -89,7 +89,7 @@ class Player:
                 drm = True
                 break
 
-            if utils.try_get(resource, "protocol") == "HLS":
+            if utils.try_get(resource, "protocol") in ("HLS", "HLS-DVR"):
                 for key in ("SD", "HD"):
                     if utils.try_get(resource, "quality") == key:
                         stream_urls[key] = utils.try_get(resource, "url")

--- a/lib/srgssr.py
+++ b/lib/srgssr.py
@@ -167,13 +167,15 @@ class SRGSSR:
                 added = True
         return purl
 
-    def open_url(self, url, use_cache=True):
+    def open_url(self, url, use_cache=True, notify_on_error=True):
         """Open and read the content given by a URL.
 
         Keyword arguments:
-        url       -- the URL to open as a string
-        use_cache -- boolean to indicate if the cache provided by the
-                     Kodi module SimpleCache should be used (default: True)
+        url              -- the URL to open as a string
+        use_cache        -- boolean to indicate if the cache provided by the
+                             Kodi module SimpleCache should be used (default: True)
+        notify_on_error  -- boolean to indicate if a UI notification should be
+                             shown on failure (default: True)
         """
         self.log("open_url, url = " + str(url))
         cache_response = (
@@ -189,7 +191,8 @@ class SRGSSR:
             response = requests.get(url, headers=headers)
             if not response.ok:
                 self.log(f"open_url: Failed to open url {url}")
-                xbmcgui.Dialog().notification(ADDON_NAME, LANGUAGE(30100), ICON, 4000)
+                if notify_on_error:
+                    xbmcgui.Dialog().notification(ADDON_NAME, LANGUAGE(30100), ICON, 4000)
                 return ""
             response.encoding = "UTF-8"
             self.cache.set(
@@ -220,12 +223,14 @@ class SRGSSR:
         data = json.loads(self.open_url(self.apiv3_url + "shows"))
         return utils.try_get(data, "data", list, [])
 
-    def get_auth_url(self, url, segment_data=None):
+    def get_auth_url(self, url, segment_data=None, notify_on_error=True):
         """
         Returns the authenticated URL from a given stream URL.
 
         Keyword arguments:
-        url -- a given stream URL
+        url              -- a given stream URL
+        notify_on_error  -- boolean to indicate if a UI notification should be
+                             shown if the token request fails (default: True)
         """
         self.log(f"get_auth_url, url = {url}")
         spl = urlps(url).path.split("/")
@@ -234,6 +239,7 @@ class SRGSSR:
                 self.open_url(
                     f"https://tp.srgssr.ch/akahd/token?acl=/{spl[1]}/{spl[2]}/*",
                     use_cache=False,
+                    notify_on_error=notify_on_error,
                 )
             )
             or {}


### PR DESCRIPTION
The DRM DASH streams default to a low-framerate slideshow preview because inputstream.adaptive selects the first adaptation set, which is a trickplay track. We resolve this by downloading the manifest, removing all trickmode adaptation sets, injecting a BaseURL, and serving the filtered XML via a temporary local HTTP server.